### PR TITLE
Add send_raw_frame function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Sends a HEADER frame
 
 Sends a DATA frame
 
+### H2.send_raw_frame(stream_id, type, flags, payload)
+
+Sends an arbitrary HTTP/2 frame.
+This functions is mainly for testing HTTP/2 server implementation, for example sending an unsupported frame type to see how the server handles it.
+Generally users are encouraged to use more specialized functions (e.g. `send_headers`) as long as they satisfy the needs.
+
 ### H2.read(timeout_ms)
 
 Reads a Frame, or times out. Returns nil on timeout

--- a/firefox.rb
+++ b/firefox.rb
@@ -43,6 +43,8 @@ begin
     h2g.send_headers(req1, 15, PRIORITY | END_STREAM, prio_low)
     h2g.send_continuation({}, 15, END_HEADERS)
     h2g.send_headers(req2, 17, 37, prio_low)
+    # Send ping frame (type=0x6) to test send_raw_frame
+    h2g.send_raw_frame(0, 0x6, 0, "76543210")
     open_streams[15] = 1
     open_streams[17] = 1
     while open_streams.length > 0

--- a/src/h2get.h
+++ b/src/h2get.h
@@ -321,6 +321,7 @@ int h2get_getp(struct h2get_ctx *ctx, const char *path, uint32_t sid, struct h2g
 int h2get_send_data(struct h2get_ctx *ctx, struct h2get_buf data, uint32_t sid, int flags, const char **err);
 int h2get_send_headers(struct h2get_ctx *ctx, struct h2get_buf *headers, size_t nr_headers, uint32_t sid, int flags, struct h2get_h2_priority *prio, int is_cont, const char **err);
 int h2get_send_goaway(struct h2get_ctx *ctx, uint32_t last_stream_id, uint32_t error_code, struct h2get_buf additional, const char **err);
+int h2get_send_raw_frame(struct h2get_ctx *ctx, uint8_t type, int flags, uint32_t sid, struct h2get_buf data, const char **err);
 const char *h2get_render_error_code(uint32_t err);
 
 int h2get_send_settings_ack(struct h2get_ctx *ctx, int timeout);

--- a/src/h2get_mruby.c
+++ b/src/h2get_mruby.c
@@ -589,6 +589,27 @@ static mrb_value h2get_mruby_send_settings_ack(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
 }
 
+static mrb_value h2get_mruby_send_raw_frame(mrb_state *mrb, mrb_value self)
+{
+    struct h2get_mruby *h2g;
+    const char *err;
+    char *data_str = NULL;
+    int ret, data_len = 0;
+    mrb_int mrb_flags, mrb_stream_id, mrb_type;
+
+    mrb_get_args(mrb, "ii|is", &mrb_stream_id, &mrb_type, &mrb_flags, &data_str, &data_len);
+
+    h2g = (struct h2get_mruby *)DATA_PTR(self);
+
+    ret = h2get_send_raw_frame(&h2g->ctx, mrb_type, mrb_flags, mrb_stream_id, H2GET_BUF(data_str, data_len), &err);
+    if (ret < 0) {
+        mrb_value exc;
+        exc = mrb_exc_new(mrb, E_RUNTIME_ERROR, err, strlen(err));
+        mrb->exc = mrb_obj_ptr(exc);
+    }
+
+    return mrb_nil_value();
+}
 static mrb_value h2get_mruby_on_settings(mrb_state *mrb, mrb_value self)
 {
     struct h2get_mruby_frame *h2g_frame;
@@ -841,6 +862,7 @@ void run_mruby(const char *rbfile, int argc, char **argv)
     mrb_define_method(mrb, h2get_mruby, "send_rst_stream", h2get_mruby_send_rst_stream, MRB_ARGS_ARG(2, 1));
     mrb_define_method(mrb, h2get_mruby, "send_window_update", h2get_mruby_send_window_update, MRB_ARGS_ARG(2, 0));
     mrb_define_method(mrb, h2get_mruby, "send_goaway", h2get_mruby_send_goaway, MRB_ARGS_ARG(2, 1));
+    mrb_define_method(mrb, h2get_mruby, "send_raw_frame", h2get_mruby_send_raw_frame, MRB_ARGS_ARG(2, 2));
 
     mrb_define_method(mrb, h2get_mruby, "get", h2get_mruby_get, MRB_ARGS_ARG(1, 0));
     mrb_define_method(mrb, h2get_mruby, "getp", h2get_mruby_getp, MRB_ARGS_ARG(3, 0));


### PR DESCRIPTION
This PR defines `send_raw_frame` function, which allows users to generate arbitrary frames.

This function is intended to test HTTP/2 server implementation, for example sending an unsupported frame type to see how the server handles it.

As a more high level background, I will need this feature to test h2o when it receives an unsupported frame type (see h2o/h2o#2225 for more details).