### PR TITLE
Send correct priority frame in send_priority

### DIFF
--- a/src/h2get.h
+++ b/src/h2get.h
@@ -270,7 +270,7 @@ struct h2get_h2_priority {
 static inline void h2get_h2_priority_set_dep_stream_id(struct h2get_h2_priority *prio, uint32_t dep_stream_id)
 {
     uint32_t excl_dep_stream_id = ntohl(prio->excl_dep_stream_id);
-    excl_dep_stream_id = (excl_dep_stream_id & 0x80000000) | (dep_stream_id | 0x7fffffff);
+    excl_dep_stream_id = (excl_dep_stream_id & 0x80000000) | (dep_stream_id & 0x7fffffff);
     prio->excl_dep_stream_id = htonl(excl_dep_stream_id);
 }
 

--- a/src/h2get.h
+++ b/src/h2get.h
@@ -284,7 +284,9 @@ static inline void h2get_h2_priority_set_exclusive(struct h2get_h2_priority *pri
 {
     uint32_t excl_dep_stream_id = ntohl(prio->excl_dep_stream_id);
     if (exclusive) {
-        excl_dep_stream_id &= 0x80000000;
+        excl_dep_stream_id |= 0x80000000;
+    } else {
+        excl_dep_stream_id &= 0x7fffffff;
     }
     prio->excl_dep_stream_id = htonl(excl_dep_stream_id);
 }


### PR DESCRIPTION
This PR fixes multiple flaws in bitwise operations for constructing a PRIORITY frame.