### PR TITLE
Enable to build with ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,8 @@ IF (NOT WITH_MRUBY_INCLUDE OR NOT WITH_MRUBY_LIB)
     ADD_CUSTOM_TARGET(mruby MRUBY_TOOLCHAIN=${MRUBY_TOOLCHAIN}
                       MRUBY_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/misc/mruby_config.rb
                       MRUBY_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}/mruby ruby minirake
-                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deps/mruby-1.2.0)
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deps/mruby-1.2.0
+                      BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/mruby/host/lib/libmruby.a")
 
     TARGET_INCLUDE_DIRECTORIES(h2get BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/deps/mruby-1.2.0/include)
     # note: the paths need to be determined before libmruby.flags.mak is generated


### PR DESCRIPTION
Some cmake generators like Ninja cannot handle implicitly generated files, failing with messages like (in case of Ninja):
```
ninja: error: 'mruby/host/lib/libmruby.a', needed by 'h2get', missing and no known rule to make it
```
The solution is just to define files with BYPRODUCTS libmruby.a libonigumo.a in ADD_CUSTOM_TARGET.
With this patch, ```cmake -G Ninja -Bb . && cmake --build b ``` works!

See also
https://github.com/h2o/h2o/pull/2504