### PR TITLE
h2get as a H2 server

### DIFF
--- a/src/h2get_read.c
+++ b/src/h2get_read.c
@@ -300,3 +300,18 @@ int h2get_read_one_frame(struct h2get_ctx *ctx, struct h2get_h2_header *header, 
     buf->buf = payload;
     return 0;
 }
+
+int h2get_expect_prefix(struct h2get_ctx *ctx, int timeout, const char **err)
+{
+    char buf[sizeof(H2GET_CONNECTION_PREFACE) - 1] = {};
+    *err = do_read(ctx, &H2GET_BUF(buf, sizeof(buf)), timeout);
+    if (*err != NULL) {
+        return -1;
+    }
+    if (memcmp(buf, H2GET_CONNECTION_PREFACE, sizeof(buf))) {
+        *err = "invalid prefix";
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/plain.c
+++ b/src/plain.c
@@ -29,6 +29,6 @@ static int plain_close(struct h2get_conn *conn, void *unused)
 }
 
 struct h2get_ops plain_ops = {
-    H2GET_TRANSPORT_PLAIN, NULL, plain_connect, NULL, NULL, plain_close, NULL,
+    H2GET_TRANSPORT_PLAIN, NULL, plain_connect, NULL, NULL, NULL, plain_close, NULL,
 };
 /* vim: set expandtab ts=4 sw=4: */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5,7 +5,37 @@
 #include <openssl/ssl.h>
 #include <poll.h>
 
-static void *ssl_init(void)
+static const unsigned char h2_proto_list[] = {2, 'h', '2'};
+
+static __attribute__((unused)) int on_alpn_select(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in, unsigned int inlen, void *arg)
+{
+    const unsigned char *in_end = in + inlen;
+    while (in != in_end) {
+        size_t cand_len = *in++;
+        if (in_end - in < cand_len) {
+            return SSL_TLSEXT_ERR_NOACK;
+        }
+        #define H2 "h2"
+        if (cand_len == strlen(H2) && memcmp(in, H2, strlen(H2)) == 0) {
+            *out = (const unsigned char *)H2;
+            *outlen = (unsigned char)strlen(H2);
+            return SSL_TLSEXT_ERR_OK;
+        }
+        #undef H2
+        in += cand_len;
+    }
+    return SSL_TLSEXT_ERR_NOACK;
+}
+
+static __attribute__((unused)) int npn_select_h2(SSL *s, unsigned char **out, unsigned char *outlen,
+                                                 const unsigned char *in, unsigned int inlen,
+                                                 void *arg)
+{
+    SSL_select_next_proto(out, outlen, in, inlen, h2_proto_list, sizeof(h2_proto_list));
+    return SSL_TLSEXT_ERR_OK;
+}
+
+static void *ssl_init(struct h2get_ctx *h2get_ctx, const char **err)
 {
     const SSL_METHOD *method;
     SSL_CTX *ctx;
@@ -15,8 +45,30 @@ static void *ssl_init(void)
     OpenSSL_add_all_algorithms();
     OpenSSL_add_all_ciphers();
 
-    method = SSLv23_client_method();
+    bool is_server = h2get_ctx_is_server(h2get_ctx);
+    method = is_server ? SSLv23_server_method() : SSLv23_client_method();
     ctx = SSL_CTX_new(method);
+    if (is_server) {
+        if (SSL_CTX_use_certificate_file(ctx, h2get_ctx->server.cert_path, SSL_FILETYPE_PEM) <= 0) {
+            *err = "failed to read cert file";
+            return NULL;
+        }
+
+        if (SSL_CTX_use_PrivateKey_file(ctx, h2get_ctx->server.key_path, SSL_FILETYPE_PEM) <= 0 ) {
+            *err = "failed to read key file";
+            return NULL;
+        }
+        SSL_CTX_set_alpn_select_cb(ctx, on_alpn_select, NULL);
+    } else {
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
+        if (SSL_CTX_set_alpn_protos(ctx, h2_proto_list, sizeof(h2_proto_list))) {
+            *err = "failed to setup alpn protocols";
+            return NULL;
+        }
+#else
+        SSL_CTX_set_next_proto_select_cb(ssl_ctx, npn_select_h2, NULL);
+#endif
+    }
 
     return ctx;
 }
@@ -48,15 +100,6 @@ __attribute__((unused)) static char *ssl_err(void)
     return errbuf;
 }
 
-static const unsigned char h2_proto_list[] = {2, 'h', '2'};
-
-static __attribute__((unused)) int npn_select_h2(SSL *s, unsigned char **out, unsigned char *outlen,
-                                                 const unsigned char *in, unsigned int inlen,
-                                                 void *arg)
-{
-    SSL_select_next_proto(out, outlen, in, inlen, h2_proto_list, sizeof(h2_proto_list));
-    return SSL_TLSEXT_ERR_OK;
-}
 static int ssl_connect(struct h2get_conn *conn, void *priv)
 {
     int ret;
@@ -89,14 +132,6 @@ static int ssl_connect(struct h2get_conn *conn, void *priv)
     if (!ret) {
         goto err2;
     }
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L || defined(LIBRESSL_VERSION_NUMBER)
-    ret = SSL_set_alpn_protos(ssl, h2_proto_list, sizeof(h2_proto_list));
-    if (ret) {
-        goto err2;
-    }
-#else
-    SSL_CTX_set_next_proto_select_cb(ssl_ctx, npn_select_h2, NULL);
-#endif
 
     SSL_set_connect_state(ssl);
 
@@ -127,6 +162,66 @@ err2:
     SSL_free(ssl);
 err1:
     close(conn->fd);
+    return -1;
+}
+
+static int ssl_accept(struct h2get_conn *listener, struct h2get_conn *conn, void *priv)
+{
+    int err;
+    SSL *ssl;
+    SSL_CTX *ssl_ctx = priv;
+
+    long ctx_opts;
+
+    if (listener->fd < 0) {
+        return -1;
+    }
+
+    conn->sa.len = sizeof(conn->sa.sa_storage);
+    conn->fd = accept(listener->fd, (void *)&conn->sa.sa_storage, &conn->sa.len);
+    if (conn->fd < 0) {
+        goto err1;
+    }
+    conn->sa.sa = (void *)&conn->sa.sa_storage;
+
+    ctx_opts = SSL_OP_ALL;
+    SSL_CTX_set_options(ssl_ctx, ctx_opts);
+    SSL_CTX_set_mode(ssl_ctx, SSL_MODE_AUTO_RETRY);
+
+    ssl = SSL_new(ssl_ctx);
+    if (!ssl) {
+        goto err1;
+    }
+    SSL_set_accept_state(ssl);
+
+    if (!SSL_set_fd(ssl, conn->fd)) {
+        goto err2;
+    }
+
+retry_connect:
+    ERR_clear_error();
+    err = SSL_accept(ssl);
+    if (err <= 0) {
+        int ssle;
+        ssle = SSL_get_error(ssl, err);
+        if (ssle == SSL_ERROR_WANT_WRITE) {
+            wait_for_write(conn->fd, -1);
+            goto retry_connect;
+        } else if (ssle == SSL_ERROR_WANT_READ) {
+            wait_for_read(conn->fd, -1);
+            goto retry_connect;
+        }
+        goto err2;
+    }
+
+    conn->state = H2GET_CONN_STATE_CONNECT;
+    conn->priv = ssl;
+    return 0;
+err2:
+    SSL_free(ssl);
+err1:
+    close(conn->fd);
+    conn->fd = -1;
     return -1;
 }
 
@@ -187,6 +282,6 @@ static void ssl_fini(void *priv)
 }
 
 struct h2get_ops ssl_ops = {
-    H2GET_TRANSPORT_SSL, ssl_init, ssl_connect, ssl_write, ssl_read, ssl_close, ssl_fini,
+    H2GET_TRANSPORT_SSL, ssl_init, ssl_connect, ssl_accept, ssl_write, ssl_read, ssl_close, ssl_fini,
 };
 /* vim: set expandtab ts=4 sw=4: */


### PR DESCRIPTION
This has been my dream for many years - scripting H2 server.

Example:
```ruby
h2g = H2.server({
  'cert_path' => '/develop/examples/h2o/server.crt',
  'key_path' => '/develop/examples/h2o/server.key',
});
h2g.listen('https://127.0.0.1:9999', 5)

loop do
  addr = h2g.accept
  p addr # e.g. ['AF_INET', '55555', '127.0.0.1', '127.0.0.1']

  h2g.expect_prefix
  h2g.send_settings

  loop do
      f = h2g.read(-1)
      puts f.to_s
      if f.type == 'SETTINGS'
        unless f.flags == ACK then
          h2g.send_settings_ack()
          break
        end
      else
        raise 'oops'
      end
  end

  loop do
    begin
      f = h2g.read(-1)
      if f.type == 'HEADERS' && f.flags & END_STREAM != 0
        res = { ":status" => "200", "content-length" => "6" }
        h2g.send_headers(res, 1, END_HEADERS)
        h2g.send_data(1, END_STREAM, "hello\n")
      end
    rescue => e
      p e
      break
    end
  end
end
```