### PR TITLE
print backtrace on exceptions

### DIFF
--- a/src/h2get_mruby.c
+++ b/src/h2get_mruby.c
@@ -1078,15 +1078,18 @@ void run_mruby(const char *rbfile, int argc, char **argv)
         printf("Failed to open file `%s`: %s\n", rbfile, strerror(errno));
         exit(EXIT_FAILURE);
     }
-    mrb_value obj = mrb_load_file(mrb, f);
+
+    mrbc_context *cxt = mrbc_context_new(mrb);
+    mrbc_filename(mrb, cxt, rbfile);
+    mrb_load_file_cxt(mrb, f, cxt);
+    mrbc_context_free(mrb, cxt);
+
     fclose(f);
     fflush(stdout);
     fflush(stderr);
 
     if (mrb->exc) {
-        obj = mrb_funcall(mrb, mrb_obj_value(mrb->exc), "inspect", 0);
-        fwrite(RSTRING_PTR(obj), RSTRING_LEN(obj), 1, stdout);
-        putc('\n', stdout);
+        mrb_print_backtrace(mrb);
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Calling mrb_print_backtrace with context object provides us with nice error message like:

```
trace (most recent call last):
        [2] /develop/t/assets/h2get-server.rb:32
        [1] /develop/t/assets/h2get-server.rb:29:in foobar
/develop/t/assets/h2get-server.rb:25:in hmmm: wrong number of arguments (given 0, expected 1) (ArgumentError)
```