### PR TITLE
boringssl does not include errno.h implicitly

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1,6 +1,6 @@
 #include "h2get.h"
+#include <errno.h>
 #include <unistd.h>
-
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <poll.h>


### PR DESCRIPTION
h2get can support boringssl just by including a file explicitly (which always a good thing to do).