### PR TITLE
off-tree build (do not touch source tree)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ ENDIF ()
 IF (NOT WITH_MRUBY_INCLUDE OR NOT WITH_MRUBY_LIB)
     ADD_CUSTOM_TARGET(mruby MRUBY_TOOLCHAIN=${MRUBY_TOOLCHAIN}
                       MRUBY_CONFIG=${CMAKE_CURRENT_SOURCE_DIR}/misc/mruby_config.rb
-                      MRUBY_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}/mruby ruby minirake
+                      MRUBY_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}/mruby
+                      INSTALL_DIR=${CMAKE_CURRENT_BINARY_DIR}/mruby-bin ruby minirake
                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deps/mruby)
 
     TARGET_INCLUDE_DIRECTORIES(h2get BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/deps/mruby/include)

--- a/misc/mruby_config.rb
+++ b/misc/mruby_config.rb
@@ -1,3 +1,5 @@
+MRuby::Lockfile.disable
+
 MRuby::Build.new do |conf|
   # load specific toolchain settings
 


### PR DESCRIPTION
At the moment, the source tree is touched in two ways:
* Mruby executables being built are installed under `deps/mruby/bin`.
* `misc/mruby_config.rb.lock` is created.

This PR changes the installation directory of the executable to a subdirectory of the build directory, and also disables the use of the lock file.