### PR TITLE
add dependency to c++ lib when building using boringssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,15 @@ ELSE ()
     SET(SSL_LIB_DIR ${H2GET_SSL_ROOT_DIR}/lib)
     SET(SSL_LIBRARIES "ssl;crypto")
 ENDIF ()
+IF (EXISTS "${SSL_INCLUDE_DIR}/openssl/base.h")
+    IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        LIST(APPEND SSL_LIBRARIES "c++")
+    ELSEIF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        LIST(APPEND SSL_LIBRARIES "stdc++")
+    ELSE ()
+        MESSAGE(FATAL_ERROR "do not know how to declare dependency on C++ stdlib even though libssl.a of boringssl depends on it")
+    ENDIF ()
+ENDIF ()
 
 INCLUDE_DIRECTORIES(
     ${SSL_INCLUDE_DIR}


### PR DESCRIPTION
When boringssl (commit 52a2c00; Oct 31 2024) is used, its libssl depends on the symbols declared in libc++ / libstdc++.

Because boringssl is built as a static library and because pkg-config is not provided, dependency has to be declared explicitly.

See also: https://github.com/h2o/picotls/pull/552