### PR TITLE
An optional second arg to `connect` overrides the SNI.  Change `to_s` for a `DATA` frame to return payload instead of dumping it to stdout.

### DIFF
--- a/src/h2get.c
+++ b/src/h2get.c
@@ -283,7 +283,7 @@ int h2get_destroy(struct h2get_ctx *ctx, const char **err)
     return 0;
 }
 
-int h2get_connect(struct h2get_ctx *ctx, struct h2get_conn *conn, struct h2get_buf url_buf, const char **err)
+int h2get_connect(struct h2get_ctx *ctx, struct h2get_conn *conn, struct h2get_buf url_buf, char *servername, const char **err)
 {
     conn_init(ctx, conn);
 
@@ -372,7 +372,12 @@ int h2get_connect(struct h2get_ctx *ctx, struct h2get_conn *conn, struct h2get_b
         }
     }
 
-    conn->servername = url.raw.host;
+    if (servername != NULL) {
+        conn->servername = H2GET_BUFSTR(servername);
+    } else {
+        conn->servername = url.raw.host;
+    }
+
     ret = conn->ops->connect(conn);
     if (ret < 0) {
         *err = "Connection failed";

--- a/src/h2get.h
+++ b/src/h2get.h
@@ -365,7 +365,7 @@ struct h2get_mruby_frame {
 struct h2get_ctx;
 void h2get_ctx_init(struct h2get_ctx *ctx);
 bool h2get_ctx_is_server(struct h2get_ctx *ctx);
-int h2get_connect(struct h2get_ctx *ctx, struct h2get_conn *conn, struct h2get_buf url_buf, const char **err);
+int h2get_connect(struct h2get_ctx *ctx, struct h2get_conn *conn, struct h2get_buf url_buf, char *servername, const char **err);
 int h2get_listen(struct h2get_ctx *ctx, struct h2get_buf url_buf, int backlog, const char **err);
 int h2get_accept(struct h2get_ctx *ctx, struct h2get_conn *conn, int timeout, const char **err);
 int h2get_destroy(struct h2get_ctx *ctx, const char **err);

--- a/src/h2get_mruby.c
+++ b/src/h2get_mruby.c
@@ -170,13 +170,12 @@ static mrb_value h2get_mruby_connect(mrb_state *mrb, mrb_value self)
         goto on_error;
     }
 
-    H2GET_MRUBY_ASSERT_ARGS(1);
-
     char *url = NULL;
-    mrb_get_args(mrb, "z", &url);
+    char *servername = NULL;
+    mrb_get_args(mrb, "z|z", &url, &servername);
 
     conn = (void *)mrb_malloc(mrb, sizeof(*conn));
-    if (h2get_connect(&h2g->ctx, &conn->conn, H2GET_BUFSTR(url), &err) != 0) {
+    if (h2get_connect(&h2g->ctx, &conn->conn, H2GET_BUFSTR(url), servername, &err) != 0) {
         goto on_error;
     }
 

--- a/src/h2get_read.c
+++ b/src/h2get_read.c
@@ -102,11 +102,36 @@ static void h2get_frame_render_window_update(struct h2get_mruby_frame *h2g_frame
     h2get_buf_printf(out, "\n\tincrement => %lu", ntohl(*(uint32_t *)payload) >> 1);
 }
 
+static void render_payload(struct h2get_buf *out, void *buf, int len)
+{
+    char *data = buf;
+    h2get_buf_printf(out, "\n================================================================================\n");
+    for (size_t offset = 0; offset < len; offset += 16) {
+        int limit = 16;
+        if (offset + limit > len)
+            limit = len - offset;
+
+	h2get_buf_printf(out, "%03x:", offset);
+	for (size_t i = 0; i < limit; i++) {
+	    h2get_buf_printf(out, " %02x", (unsigned char)data[offset + i]);
+	}
+	for (size_t i = 0; i + limit < 16; i++) {
+	    h2get_buf_printf(out, "   ");
+	}
+	h2get_buf_printf(out, " ");
+	for (size_t i = 0; i < limit; i++) {
+	    h2get_buf_printf(out, "%c", isprint(data[offset + i]) ? data[offset+i]:'.');
+	}
+	h2get_buf_printf(out, "\n");
+    }
+    h2get_buf_printf(out, "================================================================================\n\n");
+}
+
 static void h2get_frame_render_data(struct h2get_mruby_frame *h2g_frame, struct h2get_buf *out)
 {
     char *payload = h2g_frame->payload;
     size_t plen = h2g_frame->payload_len;
-    dump_zone(payload, plen);
+    render_payload(out, payload, plen);
 }
 
 static void h2get_frame_render_unknown(struct h2get_mruby_frame *h2g_frame, struct h2get_buf *out)


### PR DESCRIPTION
- In `to_s` for a `DATA` frame: return the hexdump of the payload instead of dumping it to standard output.
- An optional second arg to `connect` overrides the SNI.
